### PR TITLE
[Chore] FastAPI 백엔드 초기 환경 세팅 및 MySQL 연결 구성(back)

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,14 @@
+import os
+from dotenv import load_dotenv
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent  # app 기준 -> backend
+env_path = BASE_DIR / ".env"
+load_dotenv(dotenv_path=env_path)
+
+class Settings:
+    ENV: str = os.getenv("ENV", "local")
+    DATABASE_URL: str = os.getenv("DATABASE_URL")
+    SECRET_KEY: str = os.getenv("SECRET_KEY", "change_me_later")
+
+settings = Settings()

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,23 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+from app.config import settings
+
+if not settings.DATABASE_URL:
+    raise ValueError("DATABASE_URL is not set in environment variables")
+
+engine = create_engine(
+    settings.DATABASE_URL,
+    pool_pre_ping=True,
+)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,11 +1,17 @@
 from fastapi import FastAPI
+from app.config import settings
+from app.database import engine
 
 app = FastAPI(
     title="RePlay API",
     description="연극/영화 소품 중고거래 플랫폼 Re;Play 백엔드 API",
     version="0.1.0",
 )
-
+@app.on_event("startup")
+def on_startup():
+    print(f"ENV: {settings.ENV}")
+    print(f"DATABASE_URL: {settings.DATABASE_URL}")
+    
 @app.get("/health")
 def health_check():
     return {"status": "ok", "service": "RePlay"}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn[standard]
+python-dotenv
+SQLAlchemy
+psycopg2-binary
+pymysql


### PR DESCRIPTION
## 목적
RePlay 백엔드 개발 환경을 구축하기 위한 초기 세팅을 진행하였습니다.  
FastAPI 기본 구조를 생성하고, 로컬에서 사용할 MySQL 개발용 데이터베이스와의 연결을 구성하여 이후 기능 개발(User, Path 등)에 필요한 기반을 마련합니다.

---

## 이슈
- Closes #3 

---

## 주요 작업 내용
- backend 디렉토리 생성 및 FastAPI 기본 구조 세팅
- `app/main.py` 생성 및 기본 엔드포인트(`/health`) 추가
- `.env`, `.env.example` 구성
- `config.py` 작성: 환경 변수 로드 및 Settings 클래스 정의
- `database.py` 작성: SQLAlchemy 엔진/세션 구조 세팅
- requirements.txt 초기 패키지 추가  
  (fastapi, uvicorn, sqlalchemy, pymysql, python-dotenv)
- MySQL Workbench에서 개발용 DB(`replay_dev`) 및 사용자 생성
- `uvicorn app.main:app --reload` 실행으로 DB 연결 정상 동작 확인

---

## 산출물
backend/
├─ app/
│ ├─ main.py
│ ├─ config.py
│ ├─ database.py
│ ├─ api/
│ ├─ models/
│ ├─ schemas/
│ └─ utils/
├─ .env
├─ .env.example
├─ requirements.txt

- FastAPI 서버 정상 부팅  
- `/health` 엔드포인트에서 정상 응답 `{ "status": "ok", "service": "RePlay" }` 확인  
- DB 연결 정보 로그 출력:  
  - `ENV: local`  
  - `DATABASE_URL: mysql+pymysql://...`  

---

## 트러블슈팅
### 1) VSCode에서 `from fastapi import FastAPI` 에 밑줄 오류 발생
- 원인: 가상환경 인터프리터가 VSCode에 연결되지 않음  
- 해결: `Ctrl + Shift + P → Python: Select Interpreter → venv 선택`  
- 결과: FastAPI import 인식 정상화

### 2) `.env` 파일 로드 경로 문제
- 초기에는 프로젝트 루트가 app 기준으로 잘못 잡혀 `.env`가 로드되지 않았음  
- 해결: `BASE_DIR = Path(__file__).resolve().parent.parent` 로 경로 조정하여  
  backend/ 기준으로 `.env`를 읽도록 수정  
- 결과: 환경 변수 정상 출력 (`ENV`, `DATABASE_URL`) 확인

### 3) MySQL 연결 확인 필요
- Workbench에서 DB, 사용자 권한을 SQL로 직접 생성해야 연결 오류가 없음  
- 해결:  
  ```sql
  CREATE DATABASE replay_dev;
  CREATE USER 'replay_user'@'localhost' IDENTIFIED BY '비밀번호';
  GRANT ALL PRIVILEGES ON replay_dev.* TO 'replay_user'@'localhost';
