### PR TITLE
[Chore] CORS 설정 및 배포/브랜치 전략 문서화(back)

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -2,7 +2,7 @@ import os
 from dotenv import load_dotenv
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent.parent  # app 기준 -> backend
+BASE_DIR = Path(__file__).resolve().parent.parent  # app → backend
 env_path = BASE_DIR / ".env"
 load_dotenv(dotenv_path=env_path)
 
@@ -10,5 +10,13 @@ class Settings:
     ENV: str = os.getenv("ENV", "local")
     DATABASE_URL: str = os.getenv("DATABASE_URL")
     SECRET_KEY: str = os.getenv("SECRET_KEY", "change_me_later")
+
+    @property
+    def is_local(self) -> bool:
+        return self.ENV == "local"
+
+    @property
+    def is_production(self) -> bool:
+        return self.ENV == "production"
 
 settings = Settings()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from app.config import settings
 from app.database import engine
 
@@ -7,6 +8,24 @@ app = FastAPI(
     description="연극/영화 소품 중고거래 플랫폼 Re;Play 백엔드 API",
     version="0.1.0",
 )
+
+# CORS 설정
+origins = [
+    "http://localhost:3000",
+    "http://127.0.0.1:3000",
+    "http://localhost:5173",
+    "http://127.0.0.1:5173",
+    # 나중에 프론트 배포 URL 생기면 여기 추가
+    # "https://replay-frontend-xxxx.up.railway.app",
+]
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 @app.on_event("startup")
 def on_startup():
     print(f"ENV: {settings.ENV}")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,13 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.config import settings
 from app.database import engine
 
+tags_metadata = [
+    {
+        "name": "health",
+        "description": "배포된 RePlay 백엔드 서버의 상태를 확인하는 헬스 체크 엔드포인트입니다.",
+    },
+]
+
 app = FastAPI(
     title="RePlay API",
     description="연극/영화 소품 중고거래 플랫폼 Re;Play 백엔드 API",
@@ -31,6 +38,11 @@ def on_startup():
     print(f"ENV: {settings.ENV}")
     print(f"DATABASE_URL: {settings.DATABASE_URL}")
     
-@app.get("/health")
+@app.get(
+    "/health",
+    tags=["health"],
+    summary="헬스 체크",
+    description="Re;Play 백엔드 서버와 DB 설정이 정상적으로 동작하는지 확인합니다.",
+)
 def health_check():
     return {"status": "ok", "service": "RePlay"}

--- a/backend/run_server.bat
+++ b/backend/run_server.bat
@@ -1,0 +1,1 @@
+uvicorn app.main:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
연관 이슈  
Closes #5 

---

## 개요
RePlay 백엔드 서비스를 Railway에 배포할 수 있는 기본 환경을 구축하고,  
브랜치 전략 및 Swagger 문서를 정리했습니다.  
dev → main 머지 시 Railway에 자동 배포되도록 설정하여,  
앞으로는 개발 브랜치만 관리해도 배포가 자연스럽게 이루어지도록 하는 것이 목적입니다.

---

## 주요 내용

- CORS 설정 추가  
  - `CORSMiddleware`를 적용하여 `localhost:3000`, `localhost:5173` 등 로컬 프론트 개발 환경에서 API 호출이 가능하도록 허용
- Swagger 문서 보강  
  - `openapi_tags`를 추가하고 `/health` 엔드포인트에 `summary`/`description`/`tags`를 부여하여 Swagger 문서를 정돈
- Railway 배포 환경 정리  
  - Service Root를 `backend`로 지정
  - Build Command: `pip install -r requirements.txt`  
  - Start Command: `uvicorn app.main:app --host 0.0.0.0 --port $PORT`
- 환경 변수 구성
  - `ENV=production`
  - `DATABASE_URL=sqlite:///./replay.db` (현재는 임시 SQLite, 추후 PostgreSQL로 교체 예정)
  - `SECRET_KEY` 운영용 값 설정
- README 문서화
  - 배포 URL, Swagger URL, 로컬 실행 방법
  - 브랜치 전략(dev / main) 및 main 머지 시 자동 배포 플로우 정리

---

## 테스트

- [x] 로컬에서 `uvicorn app.main:app --reload` 실행 및 `/health`, `/docs` 응답 확인
- [x] dev 브랜치 기준 서버 실행 후 CORS 에러 없이 API 호출 가능한지 확인 (로컬 프론트 환경에서 기본 요청 테스트)
- [x] dev → main 머지 후 Railway에서 새 Deployment가 생성되는지 확인
- [x] 배포 URL에서 `/health`, `/docs`가 정상적으로 응답하는지 확인  
      - `https://replay-production-69e1.up.railway.app/health`  
      - `https://replay-production-69e1.up.railway.app/docs`

---

## 트러블 슈팅

1. **Error creating build plan with Railpack**
   - 원인: Railway가 레포 루트를 기준으로 빌드하려고 시도했지만 실제 Python 프로젝트 루트는 `backend/` 디렉토리였음
   - 해결: Service Settings에서 Root Directory를 `backend`로 변경하고  
     Build/Start Command를 명시적으로 설정하여 빌드 플랜 생성 문제 해결

2. **ValueError: DATABASE_URL is not set in environment variables**
   - 원인: `database.py`에서 `DATABASE_URL` 미설정 시 예외를 발생시키도록 되어 있는데,  
     Railway 환경 변수에 `DATABASE_URL`이 설정되지 않은 상태로 컨테이너가 실행됨
   - 해결: Service Variables 탭에 `DATABASE_URL=sqlite:///./replay.db`를 추가하고 재배포  
     이후 `/health` 및 `/docs` 정상 응답 확인

---

## 공유 사항

- 현재 배포 URL
  - Backend: `https://replay-production-69e1.up.railway.app`
  - Swagger: `https://replay-production-69e1.up.railway.app/docs`
- 브랜치 정책
  - 기능/환경 설정 작업은 `dev`에서 분기한 브랜치에서 진행
  - 검증 후 `dev`에 머지 → 일정 주기로 `dev` → `main` 머지
  - `main` 브랜치에 변경이 발생할 때마다 Railway에서 자동으로 배포가 수행됨
- 현재는 임시로 SQLite를 사용하고 있으며, 추후 Railway PostgreSQL로 전환할 예정입니다.
