### PR TITLE
[Feat] 온보딩 스플래시화면 구현(front)

### DIFF
--- a/frontend/app/screens/SplashScreen.tsx
+++ b/frontend/app/screens/SplashScreen.tsx
@@ -1,4 +1,3 @@
-// app/screens/SplashScreen.tsx
 "use client";
 
 import Image from "next/image";
@@ -17,17 +16,18 @@ export default function SplashScreen({ onSkip }: SplashProps) {
         <Image
           src="/replay-logo.svg"
           alt="리플레이 로고"
-          width={220}
-          height={220}
+          width={86}
+          height={99}
         />
 
-        <p className="mt-10 text-sm text-emerald-800">
-          대학 연극·영화 동아리 소품 순환 플랫폼
+        {/* 한 줄짜리 슬로건 + 색/크기 사진1처럼 */}
+        <p className="mt-12 text-xl text-[#004D2F]">
+          연극·영화 소품 플랫폼
         </p>
-        <p className="mt-3 text-2xl font-bold text-slate-900">리플레이</p>
 
-        <p className="mt-6 text-[11px] text-slate-400">
-          화면을 탭하면 시작합니다
+        {/* 서비스 이름 크게 */}
+        <p className="mt-2.5 text-2xl font-bold text-[#004D2F]">
+          리플레이
         </p>
       </div>
     </div>


### PR DESCRIPTION
## 개요
<!-- PR의 목적을 한 줄로 요약 -->
온보딩 화면 구현

## 변경 사항
<!-- 주요 변경 내용을 bullet로 정리 -->

- 기존 lovable 화면에 있던 온보딩 화면을 피그마에 맞게 수정하였습니다.

## 테스트
<!-- 직접 해본 테스트 목록 (백엔드: curl/Postman, 프론트: 화면 흐름 등) -->

- [로컬 서버에서 기본 플로우 동작 확인

## 이슈
<!-- 연관된 이슈 번호 -->
- Closes #13 

## 기타
<!-- 리뷰어가 참고하면 좋을 만한 추가 정보 -->
