### PR TITLE
[Chore] DB/ORM 기본 세팅 및 세션 관리 모듈화(back)

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,23 +1,80 @@
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker, declarative_base
+# app/database.py
+
+from sqlalchemy import create_engine, Column, Integer, String
+from sqlalchemy.orm import sessionmaker, declarative_base, Session
 
 from app.config import settings
 
-if not settings.DATABASE_URL:
+# --------------------------------------------------------------------
+# 1. DATABASE_URL 검증
+# --------------------------------------------------------------------
+if not getattr(settings, "DATABASE_URL", None):
+    # 기존 배포 설정과 동일하게, 환경 변수 누락 시 바로 예외 발생
     raise ValueError("DATABASE_URL is not set in environment variables")
+
+# --------------------------------------------------------------------
+# 2. SQLAlchemy Engine / Session 설정
+# --------------------------------------------------------------------
+# ENV 값에 따라 echo 옵션 등 조절 가능
+# - local / development: SQL 쿼리 로그 확인
+# - production: 조용히 동작
+is_dev = getattr(settings, "ENV", "production") != "production"
 
 engine = create_engine(
     settings.DATABASE_URL,
     pool_pre_ping=True,
+    echo=is_dev,   # 로컬 개발 환경에서만 SQL 출력
+    future=True,
 )
 
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+SessionLocal = sessionmaker(
+    autocommit=False,
+    autoflush=False,
+    bind=engine,
+    class_=Session,
+)
 
+# --------------------------------------------------------------------
+# 3. Base 선언 (모든 도메인 모델이 상속받을 부모 클래스)
+# --------------------------------------------------------------------
 Base = declarative_base()
 
+
+# --------------------------------------------------------------------
+# 4. FastAPI Dependency - get_db
+# --------------------------------------------------------------------
 def get_db():
+    """
+    요청 단위로 DB 세션을 열고, 요청이 끝나면 반드시 닫아주는 의존성 주입 함수.
+    FastAPI 엔드포인트에서 `Depends(get_db)`로 사용.
+    """
     db = SessionLocal()
     try:
         yield db
     finally:
         db.close()
+
+
+# --------------------------------------------------------------------
+# 5. 연결 테스트용 TestItem 모델 + 테이블 생성 함수
+# --------------------------------------------------------------------
+class TestItem(Base):
+    """
+    DB 연결 상태를 빠르게 검증하기 위한 테스트용 모델.
+    실제 비즈니스 로직에서는 사용하지 않고, 이후 필요 시 삭제 가능.
+    """
+    __tablename__ = "test_items"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(100), nullable=False, index=True)
+
+
+def init_test_model() -> None:
+    """
+    앱 시작 시 한 번 호출하여 DB 연결 여부를 확인하고
+    TestItem 테이블을 생성하는 용도.
+
+    - 연결 실패 시 여기에서 바로 예외가 발생하므로
+      잘못된 DATABASE_URL / 드라이버 문제를 빠르게 발견할 수 있음.
+    """
+    Base.metadata.create_all(bind=engine)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ from app.config import settings
 from app.database import engine
 from app.api.v1.router import api_router
 from app.api.v1 import realtime
+from app.database import init_test_model
 
 tags_metadata = [
     {
@@ -41,14 +42,19 @@ app.include_router(realtime.router)     # /ws/...
 
 @app.on_event("startup")
 def on_startup():
+    init_test_model()
     print(f"ENV: {settings.ENV}")
     print(f"DATABASE_URL: {settings.DATABASE_URL}")
     
 @app.get(
     "/health",
-    tags=["health"],
     summary="헬스 체크",
-    description="Re;Play 백엔드 서버와 DB 설정이 정상적으로 동작하는지 확인합니다.",
+    description=(
+        "서비스 헬스 체크용 엔드포인트입니다.\n\n"
+        "TODO: DB 세션(get_db)을 사용해 실제 DB 연결 상태도 함께 점검하도록 확장 예정."
+    ),
+    tags=["시스템"],
 )
-def health_check():
+async def health():
+    # TODO: 추후 get_db 의존성을 주입해 실제 DB 쿼리 1회 수행 후 상태를 반환하는 방식으로 확장
     return {"status": "ok", "service": "RePlay"}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,7 @@
 fastapi
 uvicorn[standard]
 python-dotenv
-SQLAlchemy
+SQLAlchemy>=2.0
 psycopg2-binary
 pymysql
+cryptography


### PR DESCRIPTION
연관 이슈  
Closes #9 

## 개요
RePlay 백엔드에서 데이터베이스 접근을 일관된 방식으로 처리하기 위해  
SQLAlchemy 기반 ORM 세션/엔진 관리 구조를 정리했습니다.

로컬(MySQL/SQLite)과 배포 환경(PostgreSQL/SQLite)을 모두  
**`DATABASE_URL` 환경 변수만 변경하면 교체 가능한 구조**로 모듈화하는 것이 목적입니다.  
또한, 간단한 테스트용 모델을 통해 앱 시작 시점에 DB 연결 여부를 빠르게 검증할 수 있도록 했습니다.

---

## 주요 내용

### 🔹 DB 엔진 및 세션 관리 모듈 정리
- `app/database.py` 정리
  - `engine` 생성 시 `settings.DATABASE_URL`을 사용하도록 통합
  - `ENV` 값에 따라 `echo` 옵션을 조정하여  
    로컬에서는 SQL 로그를 확인하고, 운영에서는 조용히 동작하도록 설정
  - `SessionLocal` 및 `get_db` 의존성 함수 정의
  - 모든 도메인 모델이 상속받을 `Base = declarative_base()` 선언

### 🔹 테스트용 모델 및 테이블 생성 로직 추가
- 테스트용 모델 `TestItem` 정의
  - `__tablename__ = "test_items"`
  - `id`, `name` 컬럼만 가진 최소 구조
- `init_test_model()` 함수에서 `Base.metadata.create_all(bind=engine)` 호출
  - 앱 시작 시점에 DB 연결 여부 및 테이블 생성 가능 여부를 확인할 수 있는 구조

### 🔹 앱 시작 시 DB 초기화 훅 연결
- `app/main.py`
  - `from app.database import init_test_model` 추가
  - `@app.on_event("startup")` 훅에서 `init_test_model()` 호출
    - 애플리케이션 기동 단계에서 DB 접속 및 테이블 생성이 한 번 수행되도록 설정

### 🔹 헬스 체크 엔드포인트에 DB 확장 TODO 명시
- `/health` 엔드포인트 description 및 주석에
  - 추후 `get_db` 의존성을 주입하여 실제 DB 쿼리를 수행한 뒤  
    DB 상태를 함께 반환하는 형태로 확장할 계획임을 TODO로 명시

### 🔹 의존성 정리
- `requirements.txt`에 ORM 관련 기본 의존성 정리
  - `SQLAlchemy`  
  - MySQL 사용 시 인증 방식을 지원하기 위한 `pymysql`, `cryptography` 추가

---

## 테스트

### 로컬(Uvicorn) 환경 테스트
- `uvicorn app.main:app --reload` 실행
  - 애플리케이션 startup 단계에서 `init_test_model()` 호출
  - DB 연결 및 `test_items` 테이블 생성 시 예외 없이 서버 정상 기동 확인
- DB 클라이언트(MySQL Workbench 등)를 통해 실제 테이블 생성 여부 확인
  - `test_items` 테이블이 생성된 것 확인
- Postman으로 다음 요청 수행
  - `GET http://localhost:8000/health`
  - 응답 예시:
    ```json
    {
      "status": "ok",
      "service": "RePlay"
    }
    ```

---

## 트러블 슈팅

### 🔧 MySQL 계정 암호화 방식으로 인한 RuntimeError
- 현상  
  - MySQL + PyMySQL 사용 시 다음 에러 발생:
    > `'cryptography' package is required for sha256_password or caching_sha2_password auth methods`
- 원인  
  - MySQL 계정이 `caching_sha2_password` / `sha256_password` 방식으로 설정되어 있어  
    PyMySQL이 암호화 연산을 위해 `cryptography` 패키지를 필요로 함
- 조치  
  - `cryptography`를 의존성에 추가하고 설치하여 문제 해결  
  - 이후 애플리케이션 startup 시 DB 연결 및 테이블 생성 정상 동작 확인

---

## 공유 사항

### DB 설정 구조
- 코드 레벨에서는 **DB 종류에 의존하지 않고**  
  `settings.DATABASE_URL`에만 의존하도록 구성
- 환경별 예시:
  - 로컬 SQLite  
    - `DATABASE_URL=sqlite:///./replay.db`
  - 로컬 MySQL  
    - `DATABASE_URL=mysql+pymysql://user:password@localhost:3306/replay_local`
  - 배포(PostgreSQL 예정)  
    - `DATABASE_URL=postgresql+psycopg2://user:password@host:5432/replay_prod`
- 추후 Railway PostgreSQL 전환 시에도  
  코드 변경 없이 환경 변수만 교체하여 대응 가능

### 이후 단계 제안
- 도메인별 실제 모델 정의 시 `Base` 상속 구조 활용
- Alembic 등 마이그레이션 도구 도입을 통해  
  스키마 변경 이력을 관리하는 이슈를 별도로 진행 예정

