### PR TITLE
[Chore] HTTP 응답 구조 일관화와 공통 Response 포맷 도입 & 전역 예외 핸들러

### DIFF
--- a/backend/app/schemas/common.py
+++ b/backend/app/schemas/common.py
@@ -1,0 +1,33 @@
+from typing import Generic, Optional, TypeVar
+from pydantic import BaseModel
+from pydantic.generics import GenericModel
+
+T = TypeVar("T")
+
+
+class ErrorInfo(BaseModel):
+    code: str
+    message: str
+
+
+class ApiResponse(GenericModel, Generic[T]):
+    success: bool
+    data: Optional[T] = None
+    error: Optional[ErrorInfo] = None
+
+
+# 성공 응답 헬퍼
+def ok(data: T):
+    return ApiResponse(success=True, data=data)
+
+
+def created(data: T):
+    return ApiResponse(success=True, data=data)
+
+
+# 실패 응답 헬퍼
+def fail(code: str, message: str):
+    return ApiResponse(
+        success=False,
+        error=ErrorInfo(code=code, message=message)
+    )

--- a/backend/app/utils/exceptions.py
+++ b/backend/app/utils/exceptions.py
@@ -1,0 +1,15 @@
+class AppException(Exception):
+    def __init__(self, message="Application Error", code="APP_ERROR", status_code=400):
+        self.message = message
+        self.code = code
+        self.status_code = status_code
+
+
+class NotFoundException(AppException):
+    def __init__(self, message="Resource Not Found"):
+        super().__init__(message, code="NOT_FOUND", status_code=404)
+
+
+class ValidationException(AppException):
+    def __init__(self, message="Validation Failed"):
+        super().__init__(message, code="VALIDATION_ERROR", status_code=422)


### PR DESCRIPTION
연관 이슈  
Closes #10 

## 개요
RePlay 백엔드의 HTTP 응답 구조를 일관화하기 위해  
공통 Response 포맷과 전역 예외 핸들러를 도입했습니다.

모든 성공/실패 응답이 동일한 JSON 구조를 따르게 되어  
프론트엔드에서 응답 처리와 에러 핸들링을 단순화하는 것이 목표입니다.

WebSocket 프로토콜은 HTTP와 구조가 다르기 때문에  
이번 작업에서는 HTTP 응답만 대상으로 적용했습니다.

---

## 주요 내용

### 🔹 공통 Response DTO 정의
- `ApiResponse[T]`, `ErrorInfo` 구조 생성
- 성공/실패 응답 헬퍼(`ok()`, `created()`, `fail()`) 추가
- 모든 API에서 동일한 응답 형태 제공 가능

### 🔹 공통 예외 클래스 정의
- `AppException`, `NotFoundException`, `ValidationException` 등 도메인 범용 예외 생성
- 서비스 계층/도메인 계층에서 예외를 일관되게 사용할 수 있도록 구조화

### 🔹 전역 예외 핸들러 적용
- FastAPI `app.exception_handler()` 등록
- `HTTPException`, `AppException`을 공통 Response 포맷으로 변환
- 에러 발생 시 동일한 JSON 응답 구조 유지

### 🔹 헬스 체크 API 응답 구조 통일
- `/health` 엔드포인트를 `ok({"service": "RePlay"})` 형태로 변경
- API 일관성을 유지하면서 시스템 정보 제공 가능

---

## 테스트

### 로컬 실행
- `uvicorn app.main:app --reload` 정상 실행
- `/health` 요청 시 공통 응답 포맷으로 정상 응답 확인
- 존재하지 않는 경로 호출 시 404가 공통 Error Response로 잘 변환됨

---

## 산출물
- `app/schemas/common.py`: 공통 응답 스키마 + 헬퍼 함수
- `app/utils/exceptions.py`: 공통 예외 클래스
- `app/main.py`: 전역 예외 핸들러 및 공통 Response 적용