### PR TITLE
[Chore] WebSocket 인프라 및 실시간 채널 기본 세팅(back)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # RePlay
 연극·영화 동아리 소품 중고거래 플랫폼 Re;Play의 백엔드/프론트엔드 모노레포입니다.
+
+## Backend Deployment
+
+- 배포 환경: Railway
+- 백엔드 베이스 URL:  
+  `https://replay-production-69e1.up.railway.app`
+- Swagger URL:  
+  `https://replay-production-69e1.up.railway.app/docs`
+
+### 브랜치 전략
+
+- `dev`  
+  - 기본 개발 브랜치  
+  - 기능 브랜치(feature/..., chore/...)는 모두 `dev`에서 분기하여 작업
+- `main`  
+  - 배포 브랜치  
+  - `dev`에서 충분히 검증된 변경 사항만 PR을 통해 머지  
+  - `main` 브랜치에 머지되면 Railway에서 자동 배포가 수행됨
+
+## WebSocket 테스트 가이드
+
+RePlay 백엔드에서는 `/ws/echo` 엔드포인트를 통해
+기본적인 WebSocket echo / broadcast 기능을 제공합니다.
+

--- a/backend/app/utils/websocket_manager.py
+++ b/backend/app/utils/websocket_manager.py
@@ -1,0 +1,59 @@
+import logging
+from typing import List, Any, Dict
+
+from fastapi import WebSocket
+
+logger = logging.getLogger("replay.websocket")
+
+
+class WebSocketManager:
+    """
+    WebSocket 연결을 관리하는 기본 매니저.
+    - 현재는 메모리 기반 리스트로 연결 관리
+    - TODO: 추후 Redis 등 외부 스토리지/브로커로 확장 가능
+    """
+
+    def __init__(self) -> None:
+        self.active_connections: List[WebSocket] = []
+
+    async def connect(self, websocket: WebSocket) -> None:
+        """
+        새로운 클라이언트 연결을 받아들이고 목록에 추가한다.
+        """
+        await websocket.accept()
+        self.active_connections.append(websocket)
+        logger.info("WebSocket connected. current=%d", len(self.active_connections))
+
+    def disconnect(self, websocket: WebSocket) -> None:
+        """
+        클라이언트 연결을 목록에서 제거한다.
+        """
+        if websocket in self.active_connections:
+            self.active_connections.remove(websocket)
+            logger.info("WebSocket disconnected. current=%d", len(self.active_connections))
+
+    async def send_personal_text(self, websocket: WebSocket, message: str) -> None:
+        await websocket.send_text(message)
+
+    async def send_personal_json(self, websocket: WebSocket, data: Dict[str, Any]) -> None:
+        await websocket.send_json(data)
+
+    async def broadcast_text(self, message: str) -> None:
+        """
+        연결된 모든 클라이언트에게 텍스트 메시지를 전송한다.
+        """
+        for connection in list(self.active_connections):
+            try:
+                await connection.send_text(message)
+            except Exception as e:
+                logger.warning("Broadcast text failed: %s", e)
+
+    async def broadcast_json(self, data: Dict[str, Any]) -> None:
+        """
+        연결된 모든 클라이언트에게 JSON 메시지를 전송한다.
+        """
+        for connection in list(self.active_connections):
+            try:
+                await connection.send_json(data)
+            except Exception as e:
+                logger.warning("Broadcast json failed: %s", e)


### PR DESCRIPTION
연관 이슈  
Closes #19

## 개요
RePlay 서비스에서 추후 알림, 실시간 거래 상태, 채팅 등의 기능을 구현하기 위해  
WebSocket 인프라(연결 관리, 브로드캐스트, 기본 메시지 포맷)를 사전에 구축했습니다.

아직 구체적인 도메인 로직은 구현하지 않고,  
echo 및 간단한 broadcast 수준에서만 동작하도록 구성하는 것이 목표였습니다.

---

## 주요 내용

### 🔹 WebSocketManager 유틸 추가
- `app/utils/websocket_manager.py` 생성
- 메모리 기반 연결 관리 기능 구현
  - `connect()`, `disconnect()`  
  - 개인 전송: `send_personal_text()`, `send_personal_json()`  
  - 전체 전송: `broadcast_text()`, `broadcast_json()`
- TODO로 추후 Redis 등 외부 스토리지/브로커로 확장 가능함을 명시

### 🔹 WebSocket 엔드포인트 정리 (/ws/echo)
- `app/api/v1/realtime.py` 수정
- `/ws/echo` 엔드포인트에서 다음 기능 제공
  - 기본 echo:
    - `{ "type": "echo", "payload": ... }` 형식의 메시지를 다시 클라이언트에게 전송
  - broadcast:
    - `{ "type": "broadcast", "payload": ... }` 메시지를 모든 연결된 클라이언트에게 브로드캐스트
- JSON 파싱 실패 시에는 단순 문자열을 `echo` 타입으로 감싸서 처리
  - 예: `"hello"` → `{ "type": "echo", "payload": "hello" }` 로 응답
- 연결/해제/메시지 처리 과정에 대해 `logger`를 통해 로그 남김

### 🔹 WebSocket 테스트 방법 문서화
- `README.md`에 WebSocket 테스트 가이드 추가
  - 로컬 서버 실행 방법 (`uvicorn app.main:app --reload`)
  - 브라우저 콘솔에서 `/ws/echo` 접속 후 echo/broadcast 테스트 예시 코드
  - `wscat`를 활용한 CLI 테스트 방법

---

## 테스트

### 로컬(Uvicorn) 환경
- `uvicorn app.main:app --reload` 실행 후 에러 없이 서버 기동 확인
- 브라우저 콘솔에서:
  - `ws://localhost:8000/ws/echo` 연결
  - `{ "type": "echo", "payload": "hello" }` 전송 시 echo 응답 정상 수신
  - `{ "type": "broadcast", "payload": "hi everyone" }` 전송 시
    여러 클라이언트에서 동일 메시지 수신 확인
- `wscat`로도 동일한 시나리오 테스트 완료

---

## 산출물
- `app/utils/websocket_manager.py`: WebSocket 연결/브로드캐스트 관리 유틸
- `app/api/v1/realtime.py`: echo/broadcast WebSocket 엔드포인트
- `README.md`: WebSocket 접속 및 테스트 방법 문서
- 로컬 검증 완료~~~~
<img width="1055" height="1175" alt="스크린샷 2025-12-12 062019" src="https://github.com/user-attachments/assets/719a19b4-6f21-4c9e-90f3-2341a82583ad" />
