### PR TITLE
[Chore] 인증 및 JWT 기반 로그인 인프라 세팅(back)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,6 @@
+ENV=local
+DATABASE_URL=mysql+pymysql://replay_user:your_password@localhost:3306/replay_dev
+SECRET_KEY=your_secret_key_here
+#배포시에는 DATABASE_URL=postgresql+psycopg2://user:password@host:5432/dbname사용
+ACCESS_TOKEN_EXPIRE_MINUTES=60
+JWT_ALGORITHM=HS256

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,6 +1,7 @@
 import os
 from dotenv import load_dotenv
 from pathlib import Path
+from pydantic import BaseSettings
 
 BASE_DIR = Path(__file__).resolve().parent.parent  # app → backend
 env_path = BASE_DIR / ".env"
@@ -10,6 +11,8 @@ class Settings:
     ENV: str = os.getenv("ENV", "local")
     DATABASE_URL: str = os.getenv("DATABASE_URL")
     SECRET_KEY: str = os.getenv("SECRET_KEY", "change_me_later")
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 60
+    JWT_ALGORITHM: str = "HS256"
 
     @property
     def is_local(self) -> bool:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,7 +1,7 @@
 import os
 from dotenv import load_dotenv
 from pathlib import Path
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 BASE_DIR = Path(__file__).resolve().parent.parent  # app → backend
 env_path = BASE_DIR / ".env"

--- a/backend/app/utils/security.py
+++ b/backend/app/utils/security.py
@@ -1,0 +1,100 @@
+from datetime import datetime, timedelta
+from typing import Dict, Optional
+
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+from pydantic import BaseModel
+
+from app.config import settings
+
+
+# --------------------------------------------------------------------
+# 1. 비밀번호 해시/검증
+# --------------------------------------------------------------------
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def hash_password(password: str) -> str:
+    """
+    평문 비밀번호를 bcrypt 해시로 변환합니다.
+    이후 DB에는 이 해시 문자열만 저장합니다.
+    """
+    return pwd_context.hash(password)
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """
+    입력된 평문 비밀번호와 DB에 저장된 해시가 일치하는지 검증합니다.
+    """
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+# --------------------------------------------------------------------
+# 2. JWT 토큰 페이로드 정의
+# --------------------------------------------------------------------
+class TokenPayload(BaseModel):
+    """
+    Access Token에 담길 기본 페이로드 구조입니다.
+
+    - sub: 사용자 ID
+    - role: 사용자 역할 (예: "ADMIN", "USER")
+    - exp: 만료 시간 (Unix timestamp) - jose 라이브러리가 내부에서 사용
+    """
+    sub: int
+    role: str
+    exp: int
+
+
+# --------------------------------------------------------------------
+# 3. JWT 발급/검증
+# --------------------------------------------------------------------
+ALGORITHM = settings.JWT_ALGORITHM
+
+
+def create_access_token(
+    data: Dict,
+    expires_delta: Optional[timedelta] = None,
+) -> str:
+    """
+    주어진 데이터(dict)를 기반으로 Access Token을 발급합니다.
+
+    data 예시:
+    {
+        "sub": user_id,
+        "role": "ADMIN" 또는 "USER"
+    }
+    """
+    to_encode = data.copy()
+
+    if expires_delta is None:
+        expires_delta = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+
+    expire = datetime.utcnow() + expires_delta
+    to_encode.update({"exp": expire})
+
+    encoded_jwt = jwt.encode(
+        to_encode,
+        settings.SECRET_KEY,
+        algorithm=ALGORITHM,
+    )
+    return encoded_jwt
+
+
+def decode_token(token: str) -> TokenPayload:
+    """
+    JWT 문자열을 디코딩하여 TokenPayload로 반환합니다.
+    검증 실패 시 JWTError 예외가 발생하며,
+    상위 레벨에서 AppException 등으로 변환해 사용할 수 있습니다.
+    """
+    try:
+        payload = jwt.decode(
+            token,
+            settings.SECRET_KEY,
+            algorithms=[ALGORITHM],
+        )
+        token_data = TokenPayload(**payload)
+        return token_data
+    except JWTError as exc:
+        # 이 단계에서는 라이브러리 예외만 던지고,
+        # 실제 API 레벨에서는 AppException으로 감싸서 공통 에러 포맷으로 응답하도록 처리 예정입니다.
+        raise exc

--- a/backend/app/utils/security.py
+++ b/backend/app/utils/security.py
@@ -65,6 +65,8 @@ def create_access_token(
     }
     """
     to_encode = data.copy()
+    if "sub" in to_encode:
+        to_encode["sub"] = str(to_encode["sub"])
 
     if expires_delta is None:
         expires_delta = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,4 @@ pymysql
 cryptography
 passlib[bcrypt]
 python-jose[cryptography]
+pydantic-settings

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,5 @@ SQLAlchemy>=2.0
 psycopg2-binary
 pymysql
 cryptography
+passlib[bcrypt]
+python-jose[cryptography]


### PR DESCRIPTION
연관 이슈  
Closes #28

## 개요
RePlay 백엔드의 인증 기능 구현을 위한 기반 인프라를 구축했습니다.  
아직 실제 회원가입/로그인 API는 만들지 않고, 이후 모든 인증 기능에서 재사용될  
비밀번호 해시/검증, JWT 발급/검증 모듈을 먼저 준비하는 것이 목적입니다.

---

## 상세 설명

### 비밀번호 해시 및 검증 유틸 추가
- `passlib[bcrypt]`을 기반으로 비밀번호 해시(`hash_password`) 및 검증(`verify_password`) 함수 구현
- 모든 사용자 비밀번호는 평문이 아닌 bcrypt 해시로 저장될 예정

### JWT 발급 및 검증 유틸 추가
- `python-jose` 기반 Access Token 발급(`create_access_token`) 및 디코딩(`decode_token`) 구현
- JWT Payload 구조(`TokenPayload`) 정의  
  - `sub`: 사용자 ID  
  - `role`: 사용자 역할(Admin/User 등)  
  - `exp`: 만료 시간  
- python-jose 요구사항에 맞춰 `sub`를 문자열로 변환하도록 처리

### JWT 설정값 환경변수화
- `ACCESS_TOKEN_EXPIRE_MINUTES`
- `JWT_ALGORITHM`
- 기존 `SECRET_KEY`는 JWT 서명에서도 재사용  
- `.env.example`에 JWT 설정 항목 추가

---

## 작업 내용
- [x] `app/utils/security.py` 생성 (비밀번호 해시/검증 + JWT 발급/검증)
- [x] `app/config.py`에 JWT 관련 설정 필드 추가  
- [x] `requirements.txt`에 의존성 추가  
  - `passlib[bcrypt]`
  - `python-jose[cryptography]`
  - `pydantic-settings`
- [x] Pydantic v2 환경에 맞춰 설정 클래스 import 경로 변경

---

## 트러블슈팅(Troubleshooting)

### 1) PydanticImportError: `BaseSettings` import 오류
**문제**
PydanticImportError: BaseSettings has been moved to the pydantic-settings package

**원인**  
현재 프로젝트는 Pydantic v2를 사용 중인데, `BaseSettings`가 더 이상 `pydantic` 패키지에 포함되지 않고  
`pydantic-settings`로 분리됨.

**해결**
- `config.py`에서 import 경로 변경  
  ```python
  from pydantic_settings import BaseSettings
- pip install pydantic-settings 후 requirements.txt 반영

### 2) bcrypt 관련 warning 메시지 발생
**문제**
(trapped) error reading bcrypt version
AttributeError: module 'bcrypt' has no attribute '__about__'

**원인**  
Windows + Anaconda 환경에서 passlib가 bcrypt backend 버전을 확인할 때 발생하는 무해한 경고.
해시/검증 기능은 정상 작동하며 서비스에 영향을 주지 않음.

**해결**
- bcrypt 최신 버전에서 발생하는 경고로, 기능에는 문제 없음을 확인
- 필요 시 bcrypt==4.1.2로 재설치하여 안정성 확보

### 3) JWTClaimsError: sub must be string
**문제**
JWTClaimsError: Subject must be a string.

**원인**  
python-jose는 JWT 표준대로 sub 값이 문자열이어야 함.
처음 구현에서는 sub를 int로 넣었기 때문에 검증에서 오류 발생.

**해결**
- create_access_token() 내부에서 자동 문자열 변환 처리
- 필요 시 bcrypt==4.1.2로 재설치하여 안정성 확보

---
## 테스트
Python REPL에서 아래 항목들을 확인 완료:
- bcrypt 해시 생성 및 검증 성공
- Access Token 정상 발급
- decode_token을 통해 Payload(sub, role, exp) 정상 파싱
- 위 트러블슈팅 조치 후 모든 동작이 정상 수행됨

---
## 참고 사항
- 아직 User 모델이 없기 때문에 sub는 단순 숫자 ID 기준으로 동작함
- 이후 계정 기반 회원가입/로그인 API 및 권한 검증 로직에서 본 모듈을 직접 활용하게 됨
- Refresh Token 구조는 향후 이슈에서 별도 도입 예정