### PR TITLE
[Chore] 공통 페이징·검색·정렬 유틸리티 세팅(back)

### DIFF
--- a/backend/app/api/v1/schools.py
+++ b/backend/app/api/v1/schools.py
@@ -1,21 +1,67 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.schemas.school import SchoolListItem
 from app.schemas.club import ClubListItem
-from app.repositories.school_repository import list_schools, list_clubs_by_school
+from app.schemas.common import ApiResponse, PageData, ok
+from app.repositories.school_repository import SchoolRepository
 
 router = APIRouter(prefix="/schools", tags=["Schools"])
 
 
-@router.get("", response_model=list[SchoolListItem])
-def get_schools(db: Session = Depends(get_db)):
-    schools = list_schools(db)
-    return schools
+@router.get(
+    "",
+    response_model=ApiResponse[PageData[SchoolListItem]],
+)
+def get_schools(
+    page: int = Query(1, ge=1),
+    size: int = Query(10, ge=1, le=100),
+    keyword: str | None = None,
+    sort: str | None = None,
+    db: Session = Depends(get_db),
+):
+    items, meta = SchoolRepository.list_schools(
+        db=db,
+        page=page,
+        size=size,
+        keyword=keyword,
+        sort=sort,
+    )
+
+    return ok(
+        PageData(
+            items=items,
+            meta=meta,
+        )
+    )
 
 
-@router.get("/{school_id}/clubs", response_model=list[ClubListItem])
-def get_school_clubs(school_id: int, db: Session = Depends(get_db)):
-    clubs = list_clubs_by_school(db, school_id)
-    return clubs
+@router.get(
+    "/{school_id}/clubs",
+    response_model=ApiResponse[PageData[ClubListItem]],
+)
+def get_school_clubs(
+    school_id: int,
+    page: int = Query(1, ge=1),
+    size: int = Query(10, ge=1, le=100),
+    keyword: str | None = None,
+    sort: str | None = None,
+    db: Session = Depends(get_db),
+):
+    items, meta = SchoolRepository.list_clubs_by_school(
+        db=db,
+        school_id=school_id,
+        page=page,
+        size=size,
+        keyword=keyword,
+        sort=sort,
+    )
+
+    return ok(
+        PageData(
+            items=items,
+            meta=meta,
+        )
+    )
+

--- a/backend/app/repositories/school_repository.py
+++ b/backend/app/repositories/school_repository.py
@@ -2,16 +2,65 @@ from sqlalchemy.orm import Session
 
 from app.models.school import School
 from app.models.club import Club
+from app.utils.pagination import (
+    paginate_query,
+    apply_keyword_filter,
+    apply_sort,
+)
 
 
-def list_schools(db: Session) -> list[School]:
-    return db.query(School).order_by(School.id.asc()).all()
+class SchoolRepository:
+    """
+    School / Club 목록 조회 전용 Repository
+    공통 페이징·검색·정렬 유틸 적용
+    """
 
+    @staticmethod
+    def list_schools(
+        db: Session,
+        page: int,
+        size: int,
+        keyword: str | None,
+        sort: str | None,
+    ):
+        query = db.query(School)
 
-def list_clubs_by_school(db: Session, school_id: int) -> list[Club]:
-    return (
-        db.query(Club)
-        .filter(Club.school_id == school_id)
-        .order_by(Club.id.asc())
-        .all()
-    )
+        # 검색 (학교명 / 지역 / 코드)
+        query = apply_keyword_filter(
+            query,
+            keyword,
+            [School.name, School.region, School.code],
+        )
+
+        # 정렬
+        query = apply_sort(query, sort, School)
+
+        # 페이징
+        return paginate_query(query, page, size)
+
+    @staticmethod
+    def list_clubs_by_school(
+        db: Session,
+        school_id: int,
+        page: int,
+        size: int,
+        keyword: str | None,
+        sort: str | None,
+    ):
+        query = (
+            db.query(Club)
+            .filter(Club.school_id == school_id)
+        )
+
+        # 검색 (동아리명 / 설명 / 장르)
+        query = apply_keyword_filter(
+            query,
+            keyword,
+            [Club.name, Club.description, Club.genre],
+        )
+
+        # 정렬
+        query = apply_sort(query, sort, Club)
+
+        # 페이징
+        return paginate_query(query, page, size)

--- a/backend/app/utils/pagination.py
+++ b/backend/app/utils/pagination.py
@@ -1,0 +1,54 @@
+from sqlalchemy.orm import Query
+from sqlalchemy import or_, asc, desc
+from math import ceil
+from typing import List
+from app.schemas.common import PaginationMeta
+
+
+def apply_keyword_filter(query: Query, keyword: str | None, columns: List):
+    if not keyword:
+        return query
+
+    return query.filter(
+        or_(*[col.ilike(f"%{keyword}%") for col in columns])
+    )
+
+
+def apply_sort(query: Query, sort: str | None, model):
+    if not sort:
+        return query
+
+    direction = asc
+    field = sort
+
+    if sort.startswith("-"):
+        direction = desc
+        field = sort[1:]
+
+    if not hasattr(model, field):
+        return query
+
+    return query.order_by(direction(getattr(model, field)))
+
+
+def paginate_query(query: Query, page: int, size: int):
+    total_items = query.count()
+    total_pages = ceil(total_items / size) if size else 1
+
+    items = (
+        query
+        .offset((page - 1) * size)
+        .limit(size)
+        .all()
+    )
+
+    meta = PaginationMeta(
+        page=page,
+        size=size,
+        total_items=total_items,
+        total_pages=total_pages,
+        has_next=page < total_pages,
+        has_prev=page > 1,
+    )
+
+    return items, meta


### PR DESCRIPTION
## 개요
거래, 물품관리, 커뮤니티 등 다양한 목록 API에서 공통으로 재사용할 수 있도록  
페이징, 검색어, 정렬 기준 처리 유틸리티를 구축합니다.

기존 API 응답 구조(ApiResponse)를 유지하면서,  
목록 조회에 필요한 메타 정보를 일관된 형태로 제공하는 것이 목적입니다.

## 변경 사항
- PaginationMeta, PageData 스키마 추가
- 공통 API 응답 구조(ApiResponse)에 페이징 데이터 포함 가능하도록 확장
- SQLAlchemy Query에 적용 가능한 공통 페이징 유틸 함수 구현
- 키워드 검색(LIKE 기반) 공통 처리 함수 추가
- 정렬 기준(sort, -sort) 공통 처리 함수 추가
- School / Club 목록 API에 시범 적용하여 동작 검증

## 테스트
- [x] 로컬 서버 기동 후 API 정상 로딩 확인
- [x] `GET /api/v1/schools` 기본 페이징 응답 확인
- [x] page / size 쿼리 파라미터 동작 확인
- [x] keyword 검색 기능 확인
- [x] sort / -sort 정렬 기준 정상 적용 확인
- [x] `GET /api/v1/schools/{school_id}/clubs` 동일 구조로 응답 확인

## 이슈
- Closes #32 

## 기타
### 설계 메모
- 공통 페이징 응답은 ApiResponse[data] 내부에 PageData 형태로 포함
- 이후 거래 / 물품관리 / 커뮤니티 / 공연 캘린더 목록 API에서 동일 유틸 재사용 예정

### 트러블 슈팅
- 기존 common schema에 PageData 정의가 누락되어 서버 시작 시 ImportError 발생
- Pagination 관련 스키마를 common에 명확히 추가하여 해결
- 응답 구조 일관성을 위해 meta를 최상위가 아닌 data 내부로 유지

