### PR TITLE
[Feat] 물품관리 도메인(Inventory) 모델 및 CRUD API 구현(back)

### DIFF
--- a/backend/app/api/v1/inventory.py
+++ b/backend/app/api/v1/inventory.py
@@ -1,15 +1,104 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, Query, HTTPException
+from sqlalchemy.orm import Session
 
-router = APIRouter(
-    prefix="/inventory",
-    tags=["물품관리"],
-)
+from app.database import get_db
+from app.schemas.common import ApiResponse, PageData, ok, created, fail
+from app.schemas.inventory import InventoryItemCreate, InventoryItemUpdate, InventoryItemOut
+from app.repositories.inventory_repository import InventoryRepository
+from app.dependencies.inventory_auth import get_current_admin_user, assert_club_admin
+from app.models.inventory_item import InventoryItem, ItemStatus
+from app.models.user import User
+
+router = APIRouter(prefix="/inventory", tags=["Inventory"])
 
 
-@router.get(
-    "/ping",
-    summary="물품관리 도메인 라우터 확인용",
-    description="TODO: 실제 물품 관리 API로 대체 예정",
-)
-async def inventory_ping():
-    return {"message": "inventory router is alive"}
+@router.post("/items", response_model=ApiResponse[InventoryItemOut])
+def create_item(
+    payload: InventoryItemCreate,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_admin_user),
+):
+    try:
+        assert_club_admin(payload.club_id, db, user)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+
+    item = InventoryItem(**payload.model_dump())
+    saved = InventoryRepository.create(db, item)
+    return created(saved)
+
+
+@router.get("/items", response_model=ApiResponse[PageData[InventoryItemOut]])
+def list_items(
+    page: int = Query(1, ge=1),
+    size: int = Query(10, ge=1, le=100),
+    sort: str | None = None,
+    keyword: str | None = None,
+    status: ItemStatus | None = None,
+    club_id: int | None = None,
+    db: Session = Depends(get_db),
+):
+    items, meta = InventoryRepository.list(
+        db=db,
+        club_id=club_id,
+        status=status,
+        keyword=keyword,
+        sort=sort,
+        page=page,
+        size=size,
+    )
+    return ok(PageData(items=items, meta=meta))
+
+
+@router.get("/items/{item_id}", response_model=ApiResponse[InventoryItemOut])
+def get_item(
+    item_id: int,
+    db: Session = Depends(get_db),
+):
+    item = InventoryRepository.get(db, item_id)
+    if not item:
+        raise HTTPException(status_code=404, detail="물품을 찾을 수 없습니다.")
+    return ok(item)
+
+
+@router.patch("/items/{item_id}", response_model=ApiResponse[InventoryItemOut])
+def update_item(
+    item_id: int,
+    payload: InventoryItemUpdate,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_admin_user),
+):
+    item = InventoryRepository.get(db, item_id)
+    if not item:
+        raise HTTPException(status_code=404, detail="물품을 찾을 수 없습니다.")
+
+    try:
+        assert_club_admin(item.club_id, db, user)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+
+    data = payload.model_dump(exclude_unset=True)
+    for k, v in data.items():
+        setattr(item, k, v)
+
+    saved = InventoryRepository.update(db, item)
+    return ok(saved)
+
+
+@router.delete("/items/{item_id}", response_model=ApiResponse[dict])
+def delete_item(
+    item_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_admin_user),
+):
+    item = InventoryRepository.get(db, item_id)
+    if not item:
+        raise HTTPException(status_code=404, detail="물품을 찾을 수 없습니다.")
+
+    try:
+        assert_club_admin(item.club_id, db, user)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+
+    InventoryRepository.delete(db, item)
+    return ok({"deleted": True})

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter
 
 from app.api.v1 import auth, trade, inventory, community, notification, mypage
-from app.api.v1 import schools, me
+from app.api.v1 import schools, me, inventory
 
 api_router = APIRouter(prefix="/api/v1")
 
@@ -13,3 +13,4 @@ api_router.include_router(mypage.router)
 api_router.include_router(auth.router)
 api_router.include_router(schools.router)
 api_router.include_router(me.router)
+api_router.include_router(inventory.router)

--- a/backend/app/dependencies/inventory_auth.py
+++ b/backend/app/dependencies/inventory_auth.py
@@ -1,0 +1,37 @@
+from fastapi import Depends
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models.user import User
+from app.models.club_admin import club_admins
+from app.dependencies.auth import get_current_user
+
+
+def assert_club_admin(
+    club_id: int,
+    db: Session,
+    user: User,
+) -> None:
+    """
+    user가 club_id의 관리자인지 확인.
+    아니면 예외를 던지도록 호출부에서 처리.
+    """
+    # club_admins association table 조회
+    q = db.execute(
+        club_admins.select().where(
+            (club_admins.c.club_id == club_id) &
+            (club_admins.c.user_id == user.id)
+        )
+    ).first()
+
+    if q is None:
+        raise PermissionError("해당 동아리의 관리자만 접근할 수 있습니다.")
+
+
+def get_current_admin_user(
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    if getattr(user, "role", None) != "ADMIN":
+        raise PermissionError("관리자만 접근할 수 있습니다.")
+    return user

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -4,3 +4,4 @@ from . import club_admin
 from .school import School
 from .club import Club
 from .user import User
+from .inventory_item import InventoryItem

--- a/backend/app/models/club.py
+++ b/backend/app/models/club.py
@@ -25,3 +25,9 @@ class Club(Base):
         secondary="club_admins",
         back_populates="managed_clubs",
         )
+    
+    inventory_items: Mapped[list["InventoryItem"]] = relationship(
+        "InventoryItem",
+        back_populates="club",
+        cascade="all, delete-orphan",
+    )

--- a/backend/app/models/inventory_item.py
+++ b/backend/app/models/inventory_item.py
@@ -1,0 +1,45 @@
+import enum
+from datetime import datetime
+
+from sqlalchemy import ForeignKey, String, Text, DateTime, Enum
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database import Base
+
+
+class ItemStatus(str, enum.Enum):
+    AVAILABLE = "AVAILABLE"
+    RESERVED = "RESERVED"
+    RENTED = "RENTED"
+    SOLD = "SOLD"
+    UNAVAILABLE = "UNAVAILABLE"
+
+
+class InventoryItem(Base):
+    __tablename__ = "inventory_items"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    club_id: Mapped[int] = mapped_column(ForeignKey("clubs.id"), index=True, nullable=False)
+
+    name: Mapped[str] = mapped_column(String(120), index=True, nullable=False)
+    category: Mapped[str | None] = mapped_column(String(80), index=True, nullable=True)
+    tags: Mapped[str | None] = mapped_column(String(255), index=True, nullable=True)
+    size: Mapped[str | None] = mapped_column(String(80), nullable=True)
+    contact: Mapped[str | None] = mapped_column(String(120), nullable=True)
+    image_path: Mapped[str | None] = mapped_column(String(500), nullable=True)
+
+    purchased_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    status: Mapped[ItemStatus] = mapped_column(
+        Enum(ItemStatus),
+        default=ItemStatus.AVAILABLE,
+        index=True,
+        nullable=False,
+    )
+
+    is_deal_done: Mapped[bool] = mapped_column(default=False, index=True, nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+    club: Mapped["Club"] = relationship("Club", back_populates="inventory_items")

--- a/backend/app/repositories/inventory_repository.py
+++ b/backend/app/repositories/inventory_repository.py
@@ -1,0 +1,57 @@
+from sqlalchemy.orm import Session
+from app.models.inventory_item import InventoryItem, ItemStatus
+from app.utils.pagination import paginate_query, apply_keyword_filter, apply_sort
+
+
+class InventoryRepository:
+
+    @staticmethod
+    def create(db: Session, item: InventoryItem) -> InventoryItem:
+        db.add(item)
+        db.commit()
+        db.refresh(item)
+        return item
+
+    @staticmethod
+    def get(db: Session, item_id: int) -> InventoryItem | None:
+        return db.query(InventoryItem).filter(InventoryItem.id == item_id).first()
+
+    @staticmethod
+    def update(db: Session, item: InventoryItem) -> InventoryItem:
+        db.add(item)
+        db.commit()
+        db.refresh(item)
+        return item
+
+    @staticmethod
+    def delete(db: Session, item: InventoryItem) -> None:
+        db.delete(item)
+        db.commit()
+
+    @staticmethod
+    def list(
+        db: Session,
+        club_id: int | None,
+        status: ItemStatus | None,
+        keyword: str | None,
+        sort: str | None,
+        page: int,
+        size: int,
+    ):
+        query = db.query(InventoryItem)
+
+        if club_id is not None:
+            query = query.filter(InventoryItem.club_id == club_id)
+
+        if status is not None:
+            query = query.filter(InventoryItem.status == status)
+
+        query = apply_keyword_filter(
+            query,
+            keyword,
+            [InventoryItem.name, InventoryItem.category, InventoryItem.tags],
+        )
+
+        query = apply_sort(query, sort, InventoryItem)
+
+        return paginate_query(query, page, size)

--- a/backend/app/schemas/inventory.py
+++ b/backend/app/schemas/inventory.py
@@ -1,0 +1,55 @@
+from datetime import datetime
+from pydantic import BaseModel, Field
+from typing import Optional, Literal
+
+from app.models.inventory_item import ItemStatus
+
+
+class InventoryItemBase(BaseModel):
+    name: str = Field(..., max_length=120)
+    category: Optional[str] = Field(None, max_length=80)
+    tags: Optional[str] = Field(None, max_length=255)
+    size: Optional[str] = Field(None, max_length=80)
+    contact: Optional[str] = Field(None, max_length=120)
+    image_path: Optional[str] = Field(None, max_length=500)
+    purchased_at: Optional[datetime] = None
+    status: ItemStatus = ItemStatus.AVAILABLE
+    is_deal_done: bool = False
+    description: Optional[str] = None
+
+
+class InventoryItemCreate(InventoryItemBase):
+    club_id: int
+
+
+class InventoryItemUpdate(BaseModel):
+    name: Optional[str] = Field(None, max_length=120)
+    category: Optional[str] = Field(None, max_length=80)
+    tags: Optional[str] = Field(None, max_length=255)
+    size: Optional[str] = Field(None, max_length=80)
+    contact: Optional[str] = Field(None, max_length=120)
+    image_path: Optional[str] = Field(None, max_length=500)
+    purchased_at: Optional[datetime] = None
+    status: Optional[ItemStatus] = None
+    is_deal_done: Optional[bool] = None
+    description: Optional[str] = None
+
+
+class InventoryItemOut(BaseModel):
+    id: int
+    club_id: int
+    name: str
+    category: Optional[str]
+    tags: Optional[str]
+    size: Optional[str]
+    contact: Optional[str]
+    image_path: Optional[str]
+    purchased_at: Optional[datetime]
+    status: ItemStatus
+    is_deal_done: bool
+    description: Optional[str]
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True

--- a/backend/app/scripts/seed_club_admins.py
+++ b/backend/app/scripts/seed_club_admins.py
@@ -1,0 +1,62 @@
+from sqlalchemy.orm import Session
+
+from app.database import SessionLocal
+from app.models.user import User, UserRole
+from app.models.club import Club
+from app.models.club_admin import club_admins
+
+
+ADMIN_EMAIL = "admin1@test.com"
+
+
+def seed_club_admin_mapping(db: Session) -> None:
+    # 1) 관리자 유저 찾기
+    user = db.query(User).filter(User.email == ADMIN_EMAIL).first()
+    if not user:
+        raise RuntimeError(f"User가 없습니다: {ADMIN_EMAIL}")
+
+    # 2) role이 ADMIN인지 보장 (아니면 ADMIN으로 변경)
+    if getattr(user, "role", None) != UserRole.ADMIN:
+        user.role = UserRole.ADMIN
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+
+    # 3) 매핑할 club 선택 (가장 첫 동아리)
+    club = db.query(Club).order_by(Club.id.asc()).first()
+    if not club:
+        raise RuntimeError("Club 데이터가 없습니다. 먼저 학교/동아리 seed를 실행하세요.")
+
+    # 4) 이미 매핑되어 있으면 skip (idempotent)
+    exists = db.execute(
+        club_admins.select().where(
+            (club_admins.c.club_id == club.id) &
+            (club_admins.c.user_id == user.id)
+        )
+    ).first()
+
+    if exists:
+        print(f"✅ 이미 매핑됨: user_id={user.id}, club_id={club.id}")
+        return
+
+    # 5) 매핑 insert
+    db.execute(
+        club_admins.insert().values(
+            club_id=club.id,
+            user_id=user.id,
+        )
+    )
+    db.commit()
+    print(f"✅ 관리자 매핑 완료: email={ADMIN_EMAIL}, user_id={user.id}, club_id={club.id}")
+
+
+def main():
+    db = SessionLocal()
+    try:
+        seed_club_admin_mapping(db)
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/scripts/seed_inventory_items.py
+++ b/backend/app/scripts/seed_inventory_items.py
@@ -1,0 +1,122 @@
+from datetime import datetime
+
+from sqlalchemy.orm import Session
+
+from app.database import SessionLocal
+from app.models.inventory_item import InventoryItem, ItemStatus
+from app.models.club import Club
+
+
+def seed_inventory(db: Session) -> None:
+    # 1) club 하나라도 있는지 확인
+    club = db.query(Club).order_by(Club.id.asc()).first()
+    if not club:
+        raise RuntimeError("Club 데이터가 없습니다. 먼저 학교/동아리 seed를 실행하세요.")
+
+    club_id = club.id
+
+    # 2) 중복 방지용 키(이름 기준)로 이미 존재하면 skip
+    seeds = [
+        {
+            "name": "무대 조명 스탠드",
+            "category": "가구",
+            "tags": "조명,무대",
+            "size": "120cm",
+            "contact": "010-1111-2222",
+            "image_path": "/images/items/light-stand.png",
+            "purchased_at": datetime(2024, 3, 1),
+            "status": ItemStatus.AVAILABLE,
+            "is_deal_done": False,
+            "description": "무대 조명 설치용 스탠드",
+        },
+        {
+            "name": "남성 정장 의상",
+            "category": "의상",
+            "tags": "정장,의상",
+            "size": "L",
+            "contact": "010-1111-2222",
+            "image_path": "/images/items/suit.png",
+            "purchased_at": datetime(2023, 10, 10),
+            "status": ItemStatus.RENTED,
+            "is_deal_done": False,
+            "description": "공연용 남성 정장",
+        },
+        {
+            "name": "소품 검",
+            "category": "소품",
+            "tags": "무기,소품",
+            "size": "90cm",
+            "contact": "010-1111-2222",
+            "image_path": "/images/items/sword.png",
+            "purchased_at": datetime(2022, 5, 20),
+            "status": ItemStatus.AVAILABLE,
+            "is_deal_done": False,
+            "description": "무대용 소품 검(안전재질)",
+        },
+        {
+            "name": "버스킹 마이크",
+            "category": "장비",
+            "tags": "음향,마이크,버스킹",
+            "size": "표준",
+            "contact": "010-1111-2222",
+            "image_path": "/images/items/mic.png",
+            "purchased_at": datetime(2024, 7, 1),
+            "status": ItemStatus.RESERVED,
+            "is_deal_done": False,
+            "description": "버스킹용 유선 마이크",
+        },
+        {
+            "name": "무대 커튼",
+            "category": "가구",
+            "tags": "커튼,무대",
+            "size": "3m",
+            "contact": "010-1111-2222",
+            "image_path": "/images/items/curtain.png",
+            "purchased_at": datetime(2021, 11, 11),
+            "status": ItemStatus.UNAVAILABLE,
+            "is_deal_done": False,
+            "description": "노후화로 사용 불가",
+        },
+        {
+            "name": "소품 의자",
+            "category": "가구",
+            "tags": "의자,소품",
+            "size": "1인용",
+            "contact": "010-1111-2222",
+            "image_path": "/images/items/chair.png",
+            "purchased_at": datetime(2020, 1, 1),
+            "status": ItemStatus.SOLD,
+            "is_deal_done": True,
+            "description": "거래 완료된 소품 의자",
+        },
+    ]
+
+    inserted = 0
+    for s in seeds:
+        exists = (
+            db.query(InventoryItem)
+            .filter(InventoryItem.club_id == club_id)
+            .filter(InventoryItem.name == s["name"])
+            .first()
+        )
+        if exists:
+            continue
+
+        item = InventoryItem(club_id=club_id, **s)
+        db.add(item)
+        inserted += 1
+
+    db.commit()
+    print(f"✅ inventory seed 완료: club_id={club_id}, inserted={inserted}")
+
+
+def main():
+    db = SessionLocal()
+    try:
+        seed_inventory(db)
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 개요
각 동아리가 보유한 물품(소품, 의상, 장비, 가구 등)을 관리하기 위한  
물품관리(Inventory) 도메인과 CRUD API를 구현합니다.

본 PR에서는 물품을 특정 Club에 귀속시키고,  
해당 Club의 관리자만 물품을 생성·수정·삭제할 수 있도록 인가를 적용했습니다.

## 변경 사항
- InventoryItem SQLAlchemy 모델 정의
  - 동아리 ID, 물품명, 종류, 태그, 사이즈, 상태, 구매일시, 이미지 경로 등 포함
- Club ↔ InventoryItem 관계 설정
- 물품 CRUD API 구현
  - 물품 생성 (POST /api/v1/inventory/items) – 관리자 전용
  - 물품 수정/삭제 (PATCH/DELETE /api/v1/inventory/items/{id}) – 관리자 전용
  - 물품 상세 조회 (GET /api/v1/inventory/items/{id})
- 물품 리스트 API 구현
  - 페이징(page, size)
  - 검색(keyword)
  - 상태 필터(status)
  - 동아리 필터(club_id)
  - 정렬(sort, -sort)
- 공통 ApiResponse + PageData(PaginationMeta) 구조 적용
- 관리자-동아리 매핑 및 인벤토리 더미 데이터 seed 스크립트 추가

## 테스트
- [x] 관리자 계정 로그인 후 JWT 토큰 발급 확인
- [x] Inventory 더미 데이터 seed 스크립트 실행 확인
- [x] 관리자-동아리 매핑 seed 스크립트 실행 확인
- [x] 물품 리스트 조회 API 동작 확인
  - 페이징 / 검색 / 상태 필터 / 정렬 정상 동작
- [x] 물품 상세 조회 API 정상 응답 확인
- [x] 관리자 권한으로 물품 생성 API 검증
- [x] 관리자 권한으로 물품 수정(PATCH) API 검증
- [x] 관리자 권한으로 물품 삭제(DELETE) API 검증
- [x] 관리자 권한이 없는 경우 403 응답 확인

## 이슈
- Closes #33 

## 기타
### 설계 메모
- 물품은 반드시 특정 Club에 속하도록 설계
- CRUD는 해당 Club의 관리자만 가능하도록 club_admins 매핑 기반 인가 적용
- 이미지 업로드는 현재 문자열 경로 기반으로 처리하며, 실제 업로드 인프라는 별도 chore 이슈에서 확장 예정
- 이후 거래 도메인은 InventoryItem 중 공개 가능한 물품을 기반으로 연동 예정

### 트러블 슈팅
- 관리자 권한 검증을 API 내부에서 분기 처리하여, Club 관리자 여부를 명확히 검증하도록 구현
- POSTMAN 검증을 위해 Inventory 및 club_admins에 대한 seed 스크립트를 분리하여 관리
