### PR TITLE
fix: 로컬 개발용 CORS 허용 범위 확장

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -39,17 +39,29 @@ async def http_exception_handler(request: Request, exc: HTTPException):
     )
 
 # CORS 설정
-origins = [
+LOCAL_ORIGINS = [
     "http://localhost:3000",
     "http://127.0.0.1:3000",
     "http://localhost:5173",
     "http://127.0.0.1:5173",
-    # 나중에 프론트 배포 URL 생기면 여기 추가
+]
+
+PROD_ORIGINS = [
+    # "https://replay-frontend.vercel.app",
     # "https://replay-frontend-xxxx.up.railway.app",
 ]
+
+if getattr(settings, "ENV", "local") == "local":
+    allow_origins = LOCAL_ORIGINS
+    allow_origin_regex = r"^http://(localhost|127\.0\.0\.1)(:\d+)?$"  # 포트 바뀌어도 OK
+else:
+    allow_origins = PROD_ORIGINS
+    allow_origin_regex = None
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=origins,
+    allow_origins=allow_origins,
+    allow_origin_regex=allow_origin_regex,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## 개요
로컬 프론트에서 백엔드 API 호출 시 CORS 정책으로 요청이 차단됩니다.

## 발생 환경
- Front: http://localhost:<port>
- Backend: http://127.0.0.1:8000
- ENV: local

## 재현 절차
1. 프론트 실행
2. API 호출(예: 로그인/목록 조회)
3. 브라우저 콘솔에 CORS 에러 발생

## 원인
- 실제 Origin 포트가 allow_origins 목록에 포함되지 않음
- 로컬 개발 환경에서 포트 변동이 잦아 고정 origin만 허용하면 재발

## 해결 방안
- 로컬 환경에서는 allow_origin_regex로 localhost/127.0.0.1의 임의 포트를 허용
- 배포 환경에서는 allow_origins에 배포 프론트 도메인을 명시적으로 등록

## 체크리스트
- [ ] 프론트에서 API 요청 성공
- [ ] OPTIONS(preflight) 응답 정상
- [ ] 배포 프론트 도메인 추가 시 정상 동작

## 이슈
Closes #66 