### PR TITLE
feat: 알림창 로그인 후 이용 가능하도록 수정

### DIFF
--- a/frontend/app/components/NotificationDrawer.tsx
+++ b/frontend/app/components/NotificationDrawer.tsx
@@ -12,10 +12,18 @@ export default function NotificationDrawer({
   open,
   onClose,
   items,
+
+  // ✅ 추가
+  isLoggedIn,
+  onGoLogin,
 }: {
   open: boolean;
   onClose: () => void;
   items: Notification[];
+
+  // ✅ 추가
+  isLoggedIn: boolean;
+  onGoLogin: () => void;
 }) {
   // ESC로 닫기
   useEffect(() => {
@@ -35,36 +43,52 @@ export default function NotificationDrawer({
   return (
     <div className="fixed inset-0 z-[60]">
       {/* 배경(클릭하면 닫힘) */}
-      <button
-        type="button"
-        aria-label="알림 닫기"
-        onClick={onClose}
-        className="absolute inset-0"
-      />
+      <button type="button" aria-label="알림 닫기" onClick={onClose} className="absolute inset-0" />
 
       {/* 오른쪽 패널 */}
       <aside className="absolute right-0 top-20 h-[620px] w-[78%] max-w-[360px] bg-white shadow-xl">
-        <div className="h-0" /> {/* AppHeader 높이만큼 띄우기 */}
+        <div className="h-0" />
 
         <div className="px-6 pt-6">
-          {sections.map((sec) => {
-            const list = items.filter((x) => x.section === sec);
-            if (list.length === 0) return null;
+          {/* ✅ 로그인 안 했을 때 */}
+          {!isLoggedIn ? (
+            <div className="pt-2">
+              <p className="flex items-center justify-center text-[16px] font-bold text-[#1A1A1A]">로그인 후 이용가능합니다.</p>
 
-            return (
-              <section key={sec} className="mb-8">
-                <p className="text-[16px] font-bold text-[#D1D6DB]">{sec}</p>
+              <button
+                type="button"
+                onClick={() => {
+                  onClose();
+                  onGoLogin();
+                }}
+                className="mt-4 w-full rounded-[12px] bg-[#0EBC81] py-3 text-[14px] font-bold text-white"
+              >
+                로그인하기
+              </button>
+            </div>
+          ) : (
+            /* ✅ 로그인 했을 때 기존 섹션 렌더 */
+            <>
+              {sections.map((sec) => {
+                const list = items.filter((x) => x.section === sec);
+                if (list.length === 0) return null;
 
-                <div className="mt-4 space-y-3">
-                  {list.map((n) => (
-                    <p key={n.id} className="text-[16px] font-medium text-[#1A1A1A]">
-                      {n.text}
-                    </p>
-                  ))}
-                </div>
-              </section>
-            );
-          })}
+                return (
+                  <section key={sec} className="mb-8">
+                    <p className="text-[16px] font-bold text-[#D1D6DB]">{sec}</p>
+
+                    <div className="mt-4 space-y-3">
+                      {list.map((n) => (
+                        <p key={n.id} className="text-[16px] font-medium text-[#1A1A1A]">
+                          {n.text}
+                        </p>
+                      ))}
+                    </div>
+                  </section>
+                );
+              })}
+            </>
+          )}
         </div>
       </aside>
     </div>

--- a/frontend/app/screens/HomeScreen.tsx
+++ b/frontend/app/screens/HomeScreen.tsx
@@ -141,7 +141,7 @@ export default function HomeScreen() {
       <NotificationDrawer
         open={notiOpen}
         onClose={() => setNotiOpen(false)}
-        isLoggedIn={auth.isLoggedIn}
+        isLoggedIn={!!auth.token}
         onGoLogin={() => {
           setNotiOpen(false);
           auth.openLogin();


### PR DESCRIPTION
## 개요
<!-- PR의 목적을 한 줄로 요약 -->
알림창을 로그인 후 이용 가능하도록 수정

## 변경 사항
<!-- 주요 변경 내용을 bullet로 정리 -->

- 알림창을 로그인 후 이용 가능하도록 수정


## 테스트
<!-- 직접 해본 테스트 목록 (백엔드: curl/Postman, 프론트: 화면 흐름 등) -->

- 로컬 서버에서 기본 플로우 동작 확인

## 이슈
<!-- 연관된 이슈 번호 -->
- Closes #105 

## 기타
<!-- 리뷰어가 참고하면 좋을 만한 추가 정보 -->
