### PR TITLE
 [Feat] 마이페이지 프로필 및 우리 공연 관리 API 구현(back)

### DIFF
--- a/backend/app/api/v1/mypage.py
+++ b/backend/app/api/v1/mypage.py
@@ -1,10 +1,11 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.dependencies.auth import get_current_user
-from app.models.user import User
+from app.models.user import User, UserRole
 from app.repositories.performance_repository import PerformanceRepository
+from app.schemas.mypage import MyProfileOut, MyProfileUpdate
 from app.schemas.performance import PerformanceOut
 
 router = APIRouter(
@@ -12,30 +13,58 @@ router = APIRouter(
     tags=["마이페이지"],
 )
 
+# --------------------
+# 5.1 프로필
+# --------------------
 
 @router.get(
-    "/ping",
-    summary="마이페이지 도메인 라우터 확인용",
-    description="TODO: 실제 마이페이지 API로 대체 예정",
+    "/profile",
+    response_model=MyProfileOut,
+    summary="내 프로필 조회",
 )
-async def mypage_ping():
-    return {"message": "mypage router is alive"}
+def get_my_profile(
+    current_user: User = Depends(get_current_user),
+):
+    return current_user
 
+
+@router.patch(
+    "/profile",
+    response_model=MyProfileOut,
+    summary="내 프로필 수정",
+)
+def update_my_profile(
+    data: MyProfileUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    if data.name is not None:
+        current_user.name = data.name
+
+    db.commit()
+    db.refresh(current_user)
+    return current_user
+
+
+# --------------------
+# 5.2 우리 공연 관리
+# --------------------
 
 @router.get(
     "/performances",
     response_model=list[PerformanceOut],
-    summary="우리 동아리 공연 일정 조회",
-    description="로그인한 사용자가 소속된 동아리의 공연 일정만 조회합니다.",
+    summary="내가 관리자(ADMIN)로 속한 동아리의 공연 조회",
 )
-def get_my_club_performances(
+def get_admin_club_performances(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """
-    - 로그인 필수
-    - 사용자의 club_id 기준으로 공연 목록 조회
-    """
+    if current_user.role != UserRole.ADMIN:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="관리자 권한이 필요합니다.",
+        )
+
     if not current_user.club_id:
         return []
 

--- a/backend/app/schemas/mypage.py
+++ b/backend/app/schemas/mypage.py
@@ -1,0 +1,18 @@
+from typing import Optional
+from pydantic import BaseModel
+
+
+class MyProfileOut(BaseModel):
+    id: int
+    email: str
+    name: str
+    role: str
+    school_id: Optional[int]
+    club_id: Optional[int]
+
+    class Config:
+        from_attributes = True
+
+
+class MyProfileUpdate(BaseModel):
+    name: Optional[str] = None


### PR DESCRIPTION
### 이슈  
Closes #38 

---

## 개요  
사용자 본인의 기본 정보와 소속 동아리 및 공연 관련 정보를 조회·관리할 수 있는 마이페이지 API를 구현했습니다.  
이미 구축된 인증·인가 인프라와 공연 도메인을 재사용하여, 마이페이지 영역에서 필요한 기능만을 명확히 분리해 제공합니다.

본 PR은 새로운 도메인을 추가하기보다는,  
기존 User / Performance 도메인을 마이페이지 관점에서 조합·정리하는 데 초점을 둡니다.

---

## 구현 범위  

### 1. 마이페이지 프로필 조회 및 수정 API  
로그인한 사용자가 자신의 기본 정보를 조회하고, 일부 허용된 필드만 수정할 수 있도록 API를 구현했습니다.

- 프로필 조회
  - 이름, 이메일, 역할
  - 소속 학교 및 동아리 정보
- 프로필 수정
  - 이름 등 일부 필드만 수정 가능
  - 이메일, 역할 등 주요 식별 정보는 수정 불가

마이페이지 전용 Response Schema를 사용하여,  
User 전체 정보가 노출되지 않도록 정보 범위를 제한했습니다.

---

### 2. 우리 공연 관리 API (조회 전용)  
앞서 구현한 공연 도메인과 연계하여,  
마이페이지에서 내가 관리자(ADMIN)로 속한 동아리의 공연 목록을 조회할 수 있는 API를 제공합니다.

- 공연 생성·수정·삭제 기능은 공연 도메인 이슈(#36)에서 담당
- 마이페이지에서는 조회 기능만 제공하여 책임 분리
- ADMIN 역할 사용자만 접근 가능하도록 인가 적용

---

### 3. 역할 기반 인가 정책 적용  
기존 PR(#30, #55)에서 구축한 역할 기반 인가 구조를 그대로 활용했습니다.

- 프로필 조회 및 수정  
  - 로그인 사용자 본인만 접근 가능
- 우리 공연 조회  
  - ADMIN 역할 사용자만 접근 가능
  - 일반 USER 접근 시 403 Forbidden 반환

이를 통해 마이페이지 영역에서도 인증 이후 인가 흐름이 일관되게 유지됩니다.

---

## 검증 방법  

### 1. 내 프로필 조회  
GET /api/v1/mypage/profile  
Authorization: Bearer <TOKEN>

결과  
- HTTP 200 OK  
- 로그인 사용자 프로필 정보 반환  

---

### 2. 내 프로필 수정  
PATCH /api/v1/mypage/profile  
Authorization: Bearer <TOKEN>

요청 바디 예시  
{
  "name": "변경된 이름"
}

결과  
- HTTP 200 OK  
- 수정된 프로필 정보 반환  

---

### 3. 우리 공연 조회 (ADMIN)  
GET /api/v1/mypage/performances  
Authorization: Bearer <ADMIN_TOKEN>

결과  
- HTTP 200 OK  
- 관리자 소속 동아리의 공연 목록 반환  

---

### 4. 일반 USER 접근  
GET /api/v1/mypage/performances  
Authorization: Bearer <USER_TOKEN>

결과  
- HTTP 403 Forbidden  
- 관리자 권한 필요 메시지 반환  

---

## 트러블 슈팅 정리  

### 문제 1. 마이페이지에서 User 전체 정보 노출 우려  

원인  
기존 User 스키마를 그대로 사용할 경우, 마이페이지에서 불필요한 필드까지 노출될 가능성이 있음  

해결  
마이페이지 전용 Profile Schema를 정의하여,  
조회 및 수정 가능한 필드만 명확히 제한  

---

### 문제 2. 우리 공연 조회 기준의 모호함  

원인  
단순히 club_id 기준으로 조회할 경우, 일반 사용자도 접근 가능해질 수 있음  

해결  
User.role == ADMIN 조건을 명확히 적용하여  
관리자 권한 사용자만 우리 공연 조회 가능하도록 인가 정책 강화  

---

## 참고 사항  

- 본 PR은 마이페이지 영역 중 프로필 및 공연 관리 기능에 한정  
- 알림, 예약 현황, 내가 작성한 글 등은 후속 이슈에서 확장 예정  
- 공연 도메인 및 인증·인가 인프라는 기존 PR(#36, #30, #55)을 그대로 재사용
