### PR TITLE
[Feat] 로그아웃 API 구현 및 인증 세션 종료 인터페이스 제공(back)

### DIFF
--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from app.database import get_db
-from app.dependencies.auth import require_admin
+from app.dependencies.auth import require_admin, get_current_user
 from app.schemas.common import ok
 from app.schemas.user import UserCreate, UserLogin, UserResponse
 from app.services.user_service import UserService
@@ -22,6 +22,15 @@ def login(data: UserLogin, db: Session = Depends(get_db)):
     return ok(token)
 
 
+@router.post("/logout")
+def logout(
+    current_user: UserResponse = Depends(get_current_user),
+):
+    return ok({
+        "message": "로그아웃 되었습니다."
+    })
+
+
 @router.get("/admin-test")
 def admin_test(
     current_user: UserResponse = Depends(require_admin),
@@ -31,4 +40,3 @@ def admin_test(
         "user_id": current_user.id,
         "role": current_user.role,
     })
-


### PR DESCRIPTION
### 이슈  
Closes #121 

---

## 개요  
JWT 기반 인증 구조에서 클라이언트의 로그아웃 흐름을 명확히 지원하기 위해  
로그아웃 API를 구현했습니다.

본 PR은 서버 세션을 유지하지 않는 JWT 특성을 고려하여,  
토큰을 직접 파기하는 방식이 아닌 **인증된 사용자에 대한 명시적 로그아웃 인터페이스 제공**에 초점을 둡니다.

---

## 구현 범위  

### 1. 로그아웃 API 추가  
로그인한 사용자가 호출할 수 있는 로그아웃 엔드포인트를 추가했습니다.

- `POST /api/v1/auth/logout`
- 인증된 요청만 허용
- 성공 시 클라이언트가 토큰을 폐기할 수 있도록 명확한 응답 반환

기존 로그인·회원가입 API와 동일한 공통 응답 포맷을 사용하여,  
Auth 도메인 내 응답 일관성을 유지했습니다.

---

### 2. 기존 인증 인프라 재사용  
이미 구현된 JWT 인증 흐름을 그대로 활용했습니다.

- `get_current_user` 의존성을 사용하여 로그인 상태 검증
- 토큰이 없거나 유효하지 않은 경우 기존 인증 예외 처리 로직 적용
- 추가적인 DB 저장 또는 세션 관리 로직 없음

---

### 3. 확장 가능성 고려  
이번 PR에서는 서버 측 토큰 무효화는 구현하지 않았으며,  
향후 다음과 같은 확장을 고려할 수 있는 구조를 유지했습니다.

- Refresh Token 도입
- Redis 기반 Token Blacklist
- 다중 기기 로그인 환경에서의 로그아웃 정책 확장

---

## 검증 방법  

### 1. 로그인 상태에서 로그아웃  
POST /api/v1/auth/logout  
Authorization: Bearer <ACCESS_TOKEN>

결과  
- HTTP 200 OK  
- 로그아웃 성공 메시지 반환  

---

### 2. 토큰 없이 로그아웃 요청  
POST /api/v1/auth/logout  

결과  
- HTTP 401 Unauthorized  
- 로그인 필요 메시지 반환  

---

## 트러블 슈팅 정리  

### 문제. JWT 환경에서 로그아웃 처리 방식의 모호함  

원인  
JWT는 서버에서 세션을 유지하지 않기 때문에,  
전통적인 “세션 파기” 방식의 로그아웃이 적용되지 않음  

해결  
로그아웃을 “토큰 무효화 요청 인터페이스 제공”의 의미로 정의하고,  
인증된 사용자만 접근 가능한 로그아웃 API를 제공하여  
클라이언트 인증 상태 정리를 명확히 함  

---

## 참고 사항  

- 본 PR은 JWT 기반 인증 구조에서의 기본 로그아웃 흐름을 완성하는 단계
- 서버 측 토큰 무효화는 후속 이슈에서 확장 가능
- 기존 로그인·인가 로직(#29, #30, #55)과 충돌 없이 동작
