### PR TITLE
[Feat] 알림 도메인 및 HTTP/WebSocket 알림 API 구현(back)

### DIFF
--- a/backend/app/api/v1/notification.py
+++ b/backend/app/api/v1/notification.py
@@ -1,15 +1,68 @@
-from fastapi import APIRouter
+from __future__ import annotations
 
-router = APIRouter(
-    prefix="/notifications",
-    tags=["알림"],
-)
+from math import ceil
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.dependencies.auth import get_current_user
+from app.models.user import User
+from app.repositories.notification_repository import NotificationRepository
+from app.schemas.common import ok, PageData, PaginationMeta
+from app.schemas.notification import NotificationOut
+
+router = APIRouter(prefix="/notifications", tags=["Notifications"])
 
 
-@router.get(
-    "/ping",
-    summary="알림 도메인 라우터 확인용",
-    description="TODO: 실제 알림 API로 대체 예정",
-)
-async def notification_ping():
-    return {"message": "notification router is alive"}
+@router.get("")
+def list_notifications(
+    page: int = Query(1, ge=1),
+    size: int = Query(20, ge=1, le=100),
+    is_read: Optional[bool] = Query(None),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    items, total = NotificationRepository.list_for_user(
+        db=db,
+        user_id=current_user.id,
+        is_read=is_read,
+        page=page,
+        size=size,
+    )
+
+    total_pages = ceil(total / size) if size else 0
+    meta = PaginationMeta(
+        page=page,
+        size=size,
+        total=total,
+        total_pages=total_pages,
+        has_next=page < total_pages,
+        has_prev=page > 1,
+    )
+    data = PageData[NotificationOut](
+        items=[NotificationOut.model_validate(i) for i in items],
+        meta=meta,
+    )
+    return ok(data)
+
+
+@router.post("/{notification_id}/read")
+def mark_notification_read(
+    notification_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    n = NotificationRepository.get_by_id(db, notification_id)
+    if not n:
+        raise HTTPException(status_code=404, detail="알림을 찾을 수 없습니다.")
+
+    if n.recipient_user_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="본인 알림만 처리할 수 있습니다.",
+        )
+
+    n = NotificationRepository.mark_read(db, n)
+    return ok(NotificationOut.model_validate(n))

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter
 
 from app.api.v1 import auth, trade, inventory, community, notification, mypage
-from app.api.v1 import schools, me, trade, performances
+from app.api.v1 import schools, me, trade, performances, realtime
 
 api_router = APIRouter(prefix="/api/v1")
 
@@ -16,3 +16,4 @@ api_router.include_router(me.router)
 api_router.include_router(inventory.router)
 api_router.include_router(trade.router)
 api_router.include_router(performances.router)
+api_router.include_router(realtime.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -9,3 +9,4 @@ from .trade_listing import TradeListing
 from .trade_reservation import TradeReservation
 from .community_post import CommunityPost
 from .performance import Performance
+from .notification import Notification

--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import enum
+from datetime import datetime
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, Enum, Text, ForeignKey, Index
+from app.database import Base
+
+
+class NotificationType(str, enum.Enum):
+    ITEM_CHECK = "ITEM_CHECK"
+    TRADE_STATUS = "TRADE_STATUS"
+    POST_COMMENT = "POST_COMMENT"
+    POST_REPLY = "POST_REPLY"
+    REQUEST_RESPONSE = "REQUEST_RESPONSE"
+
+
+class Notification(Base):
+    __tablename__ = "notifications"
+
+    id = Column(Integer, primary_key=True, index=True)
+
+    recipient_user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+
+    type = Column(Enum(NotificationType), nullable=False, index=True)
+
+    # 관련 엔티티 식별자(게시글 id, 거래 id, 물품 id 등)
+    entity_id = Column(Integer, nullable=True, index=True)
+
+    # payload를 json으로 저장하고 싶으면 JSON 컬럼으로 바꾸면 됨
+    payload = Column(Text, nullable=True)
+
+    message = Column(String(500), nullable=False)
+
+    is_read = Column(Boolean, nullable=False, default=False, index=True)
+
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+    __table_args__ = (
+        Index("ix_notifications_recipient_created", "recipient_user_id", "created_at"),
+    )

--- a/backend/app/repositories/notification_repository.py
+++ b/backend/app/repositories/notification_repository.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+from sqlalchemy import desc
+from typing import Optional, Tuple, List
+
+from app.models.notification import Notification, NotificationType
+
+
+class NotificationRepository:
+    @staticmethod
+    def create(
+        db: Session,
+        recipient_user_id: int,
+        type: NotificationType,
+        message: str,
+        entity_id: Optional[int] = None,
+        payload: Optional[str] = None,
+    ) -> Notification:
+        n = Notification(
+            recipient_user_id=recipient_user_id,
+            type=type,
+            message=message,
+            entity_id=entity_id,
+            payload=payload,
+            is_read=False,
+        )
+        db.add(n)
+        db.commit()
+        db.refresh(n)
+        return n
+
+    @staticmethod
+    def get_by_id(db: Session, notification_id: int) -> Optional[Notification]:
+        return db.query(Notification).filter(Notification.id == notification_id).first()
+
+    @staticmethod
+    def list_for_user(
+        db: Session,
+        user_id: int,
+        is_read: Optional[bool],
+        page: int,
+        size: int,
+    ) -> Tuple[List[Notification], int]:
+        q = db.query(Notification).filter(Notification.recipient_user_id == user_id)
+        if is_read is not None:
+            q = q.filter(Notification.is_read == is_read)
+
+        total = q.count()
+        items = (
+            q.order_by(desc(Notification.created_at))
+            .offset((page - 1) * size)
+            .limit(size)
+            .all()
+        )
+        return items, total
+
+    @staticmethod
+    def mark_read(db: Session, notification: Notification) -> Notification:
+        notification.is_read = True
+        db.commit()
+        db.refresh(notification)
+        return notification

--- a/backend/app/schemas/notification.py
+++ b/backend/app/schemas/notification.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+from pydantic import BaseModel
+
+
+class NotificationOut(BaseModel):
+    id: int
+    recipient_user_id: int
+    type: str
+    entity_id: Optional[int] = None
+    payload: Optional[str] = None
+    message: str
+    is_read: bool
+    created_at: datetime
+
+    class Config:
+        from_attributes = True

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app.models.notification import NotificationType
+from app.repositories.notification_repository import NotificationRepository
+from app.utils.websocket_manager import WebSocketManager
+from app.schemas.notification import NotificationOut
+
+# 전역 WebSocket 매니저 (echo와 공유)
+ws_manager = WebSocketManager()
+
+
+class NotificationService:
+    @staticmethod
+    async def notify_user(
+        db: Session,
+        user_id: int,
+        type: NotificationType,
+        message: str,
+        entity_id: Optional[int] = None,
+        payload: Optional[str] = None,
+    ):
+        # 1) DB 저장
+        n = NotificationRepository.create(
+            db=db,
+            recipient_user_id=user_id,
+            type=type,
+            message=message,
+            entity_id=entity_id,
+            payload=payload,
+        )
+
+        # 2) WebSocket 실시간 푸시 (broadcast)
+        await ws_manager.broadcast_json(
+            {
+                "type": "NOTIFICATION",
+                "data": NotificationOut.model_validate(n).model_dump(),
+            }
+        )
+
+        return n


### PR DESCRIPTION
### 이슈  
Closes #37 

---

## 개요  
물품 점검, 게시판 활동 등 서비스 내 주요 이벤트를 사용자에게 전달하기 위한  
알림(Notification) 도메인을 구현했습니다.

본 PR에서는 **알림 데이터 관리 + HTTP 조회 API + WebSocket 기반 실시간 전달 구조**를 함께 설계·구현하여,  
동기/비동기 알림 전달 흐름을 모두 지원하는 기반을 마련했습니다.

---

## 구현 범위  

### 1. Notification 도메인 모델 구현  
사용자 알림을 표현하기 위한 Notification 엔티티를 정의했습니다.

- 수신자(User)
- 알림 타입(NotificationType)
- 관련 엔티티 ID
- 메시지 및 payload 정보
- 읽음 여부
- 생성 시각

이를 통해 게시글 댓글, 거래 상태 변경, 물품 점검 등 다양한 알림 시나리오를 확장 가능하게 구성했습니다.

---

### 2. HTTP 기반 알림 조회 / 읽음 처리 API  

#### 알림 목록 조회
- `GET /api/v1/notifications`
- 페이징 지원
- 읽음 / 안읽음 필터 지원

#### 알림 읽음 처리
- `POST /api/v1/notifications/{id}/read`
- 본인 알림만 처리 가능
- 읽음 상태 업데이트

모든 응답은 공통 API Response 포맷을 사용합니다.

---

### 3. 알림 발행 유틸리티 구현  

도메인 간 결합도를 낮추기 위해 알림 발행을 공통 유틸 형태로 분리했습니다.

- `notify_user(user_id, type, message, entity_id, payload)`
- 알림 DB 저장
- 이후 WebSocket 실시간 푸시까지 연계 가능

실제 트리거(댓글 작성, 거래 생성 등)는 각 도메인 이슈에서 연결하도록 설계했습니다.

---

### 4. WebSocket 기반 실시간 알림 전송  

기존 echo WebSocket 인프라를 재사용하여 알림 푸시를 구현했습니다.

- 단일 서버 메모리 기반 WebSocketManager 사용
- 서버 발행 알림은 `type = "NOTIFICATION"` 메시지로 전송
- 클라이언트 송신용 echo/broadcast 기능은 유지

#### WebSocket 메시지 스펙
```json
{
  "type": "NOTIFICATION",
  "data": {
    "id": 1,
    "recipient_user_id": 3,
    "type": "POST_COMMENT",
    "entity_id": 10,
    "message": "내 게시글에 댓글이 달렸습니다.",
    "is_read": false,
    "created_at": "2025-12-19T12:00:00Z"
  }
}
