### PR TITLE
feat: 비회원 상태일때 마이페이지 클릭 시 로그인 팝업 활성화

### DIFF
--- a/frontend/app/screens/HomeScreen.tsx
+++ b/frontend/app/screens/HomeScreen.tsx
@@ -118,6 +118,20 @@ export default function HomeScreen() {
   };
 
   const handleTabChange = (tab: BottomTabKey) => {
+    if (tab === "mypage") {
+    auth.requireLogin(() => {
+      if (tab === activeTab) {
+        setTabNonce((n) => n + 1);
+        resetToBase();
+        return;
+      }
+      setActiveTab(tab);
+      setTabNonce((n) => n + 1);
+      resetToBase();
+    });
+    return;
+  }
+    
     if (tab === activeTab) {
       setTabNonce((n) => n + 1);
       resetToBase();
@@ -285,7 +299,11 @@ export default function HomeScreen() {
               />
             )}
 
-            {activeTab === "mypage" && <MyPageScreen tabNonce={tabNonce} onDetailModeChange={setHeaderHidden} />}
+            {activeTab === "mypage" && (
+              auth.isLoggedIn ? (
+                <MyPageScreen tabNonce={tabNonce} onDetailModeChange={setHeaderHidden} />
+              ) : null
+            )}
           </>
         )}
       </main>


### PR DESCRIPTION
## 개요
<!-- PR의 목적을 한 줄로 요약 -->
비회원 상태일때 마이페이지 클릭 시 로그인 팝업 활성화

## 변경 사항
<!-- 주요 변경 내용을 bullet로 정리 -->

- 비회원 상태일때 마이페이지 클릭 시 로그인 팝업 활성화

## 테스트
<!-- 직접 해본 테스트 목록 (백엔드: curl/Postman, 프론트: 화면 흐름 등) -->

- 로컬 서버에서 기본 플로우 동작 확인

## 이슈
<!-- 연관된 이슈 번호 -->
- Closes #129 

## 기타
<!-- 리뷰어가 참고하면 좋을 만한 추가 정보 -->
